### PR TITLE
Phase 1.1: Add comprehensive compiler warnings and static analysis tools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,6 +63,22 @@ AM_CCASFLAGS += \
 AM_CFLAGS += \
 	-Wall -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes
 
+# Phase 1.1: Add comprehensive compiler warnings for better code quality
+# These additional warnings help catch common issues early
+AM_CFLAGS += \
+	-Wextra \
+	-Wshadow \
+	-Wpointer-arith \
+	-Wcast-align \
+	-Wwrite-strings \
+	-Wredundant-decls \
+	-Wnested-externs \
+	-Winline \
+	-Wno-long-long \
+	-Wuninitialized \
+	-Wconversion \
+	-Wstrict-overflow=2
+
 # We need the GNU-style inline
 AM_CFLAGS += \
 	-fgnu89-inline

--- a/docs/phase1-quick-fixes.md
+++ b/docs/phase1-quick-fixes.md
@@ -1,0 +1,76 @@
+# Phase 1 Quick Fixes Implementation
+
+This document tracks the quick fixes implemented from the GNU Mach Development Roadmap Phase 1.
+
+## Completed Quick Fixes
+
+### 1. Enhanced Compiler Warnings (Phase 1.1)
+- **File Modified**: `Makefile.am`
+- **Changes**: Added comprehensive compiler warning flags to catch more potential issues:
+  - `-Wextra`: Extra warning flags
+  - `-Wshadow`: Warn about variable shadowing
+  - `-Wpointer-arith`: Warn about pointer arithmetic issues
+  - `-Wcast-align`: Warn about casting that increases alignment
+  - `-Wwrite-strings`: Warn about string literal modifications
+  - `-Wredundant-decls`: Warn about redundant declarations
+  - `-Wnested-externs`: Warn about nested extern declarations
+  - `-Winline`: Warn when inline functions can't be inlined
+  - `-Wuninitialized`: Warn about uninitialized variables
+  - `-Wconversion`: Warn about type conversions
+  - `-Wstrict-overflow=2`: Warn about potential overflow issues
+
+### 2. Static Analysis Script (Phase 1.1)
+- **File Created**: `scripts/run-static-analysis.sh`
+- **Purpose**: Automated script to run various static analysis tools:
+  - cppcheck for C/C++ static analysis
+  - clang static analyzer via scan-build
+  - Compiler warnings check with -Werror
+- **Usage**: `./scripts/run-static-analysis.sh`
+
+## Identified Issues for Future Work
+
+### 1. Console Timestamps
+- **Status**: Already implemented! 
+- **Location**: `kern/printf.c`
+- **Features**: High-resolution timestamps, enable/disable functionality
+- **Test**: `tests/test-console-timestamp.c`
+
+### 2. Magic Numbers and Constants
+Several areas with magic numbers were identified that should be replaced with named constants:
+- Device flags in `include/device/tty_status.h`
+- IPC kobject types in `kern/ipc_kobject.h`
+- Processor states in `kern/processor.h`
+- Run queue configuration in `kern/sched.h`
+
+### 3. Strict Aliasing Issues
+Potential strict aliasing violations found:
+- Type punning through unions in `kern/gsync.c`
+- Buffer control structures in `kern/slab.c`
+- Unsafe casts in `kern/exception.c` and `kern/thread.c`
+
+## Next Steps
+
+1. **Run Static Analysis**: Execute the static analysis script to identify specific issues
+2. **Fix Compiler Warnings**: Build with new warning flags and fix any issues found
+3. **Constants Cleanup**: Replace magic numbers with named constants
+4. **Strict Aliasing**: Audit and fix type punning issues
+5. **GDB Stubs**: Update GDB stub implementation for modern GDB versions
+6. **Build System**: Modernize autotools configuration
+
+## How to Test
+
+1. Configure and build with new warnings:
+   ```bash
+   ./configure --host=i686-gnu
+   make
+   ```
+
+2. Run static analysis:
+   ```bash
+   ./scripts/run-static-analysis.sh
+   ```
+
+3. Review generated reports:
+   - `cppcheck-report.txt`
+   - `compiler-warnings.txt`
+   - `build-analyze/scan-results/`

--- a/scripts/run-static-analysis.sh
+++ b/scripts/run-static-analysis.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Static analysis script for GNU Mach - Phase 1.1 Code Quality
+# This script runs various static analysis tools to identify potential issues
+
+set -e
+
+echo "=== GNU Mach Static Analysis ==="
+echo "Running static analysis tools to identify code quality issues..."
+echo
+
+# Check if tools are available
+check_tool() {
+    if ! command -v $1 &> /dev/null; then
+        echo "Warning: $1 not found. Please install it for complete analysis."
+        return 1
+    fi
+    return 0
+}
+
+# Run cppcheck if available
+if check_tool cppcheck; then
+    echo "=== Running cppcheck ==="
+    cppcheck --enable=all --error-exitcode=0 \
+             --suppress=missingIncludeSystem \
+             --suppress=unmatchedSuppression \
+             --inline-suppr \
+             -I include -I i386/include -I x86_64/include \
+             kern/*.c ipc/*.c vm/*.c device/*.c 2>&1 | tee cppcheck-report.txt
+    echo "Cppcheck report saved to cppcheck-report.txt"
+    echo
+fi
+
+# Run clang static analyzer if available
+if check_tool clang; then
+    echo "=== Running clang static analyzer ==="
+    # Create a build directory for scan-build
+    mkdir -p build-analyze
+    cd build-analyze
+    
+    if check_tool scan-build; then
+        scan-build ../configure --host=i686-gnu
+        scan-build -o scan-results make -j$(nproc)
+        echo "Clang static analyzer results saved in build-analyze/scan-results/"
+    else
+        echo "scan-build not found. Install clang-tools for static analysis."
+    fi
+    cd ..
+    echo
+fi
+
+# Run compiler with extra warnings to identify issues
+echo "=== Checking for compiler warnings ==="
+echo "Building with -Werror to identify all warnings..."
+mkdir -p build-warnings
+cd build-warnings
+../configure --host=i686-gnu CFLAGS="-g -O2 -Werror" || true
+make -j$(nproc) 2>&1 | tee ../compiler-warnings.txt || true
+cd ..
+echo "Compiler warnings saved to compiler-warnings.txt"
+echo
+
+echo "=== Static analysis complete ==="
+echo "Review the following files for issues:"
+echo "  - cppcheck-report.txt"
+echo "  - compiler-warnings.txt"
+echo "  - build-analyze/scan-results/ (if clang analyzer was run)"


### PR DESCRIPTION
- Enhanced compiler warning flags in Makefile.am to catch more issues early
- Created automated static analysis script for cppcheck and clang analyzer
- Documented quick fixes and identified areas for future cleanup
- Console timestamps already implemented (no changes needed)

This addresses the 'Code Quality & Standards' section of Phase 1 from issue #12