### PR TITLE
Fix missing kernel map base macro

### DIFF
--- a/i386/i386/vm_param.h
+++ b/i386/i386/vm_param.h
@@ -31,6 +31,14 @@
 #include <xen/public/xen.h>
 #endif
 
+#ifndef KERNEL_MAP_BASE
+#ifdef __x86_64__
+#define KERNEL_MAP_BASE 0xffffffff80000000ULL
+#else
+#define KERNEL_MAP_BASE 0xC0000000UL
+#endif
+#endif
+
 /* To avoid ambiguity in kernel code, make the name explicit */
 #define VM_MIN_USER_ADDRESS VM_MIN_ADDRESS
 #define VM_MAX_USER_ADDRESS VM_MAX_ADDRESS

--- a/tmp_build_check.c
+++ b/tmp_build_check.c
@@ -1,0 +1,8 @@
+#include "i386/i386/vm_param.h"
+
+int kernel_map_base_nonzero = (KERNEL_MAP_BASE != 0);
+unsigned long long vm_min_kernel_address_copy = (unsigned long long) VM_MIN_KERNEL_ADDRESS;
+
+int main(void) {
+    return (kernel_map_base_nonzero && (vm_min_kernel_address_copy != 0)) ? 0 : 1;
+}


### PR DESCRIPTION
Adds a guarded definition for `KERNEL_MAP_BASE` in `i386/i386/vm_param.h` to resolve build failures due to an undeclared macro.

The build was failing because `KERNEL_MAP_BASE` was undeclared, preventing `VM_MIN_KERNEL_ADDRESS` from resolving correctly. This change provides a default, architecture-specific definition for `KERNEL_MAP_BASE` (0xffffffff80000000ULL for x86_64, 0xC0000000UL for i386) within `vm_param.h`, guarded by `#ifndef`, ensuring compatibility without overriding values potentially provided by the build system.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3ac4ae8-bf08-482d-a880-b738c48607d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f3ac4ae8-bf08-482d-a880-b738c48607d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

