### PR TITLE
Fix missing gdb_stub_init symbol in GNU Mach build

### DIFF
--- a/Makefrag.am
+++ b/Makefrag.am
@@ -68,6 +68,10 @@ libkernel_a_SOURCES += \
 
 # We need frame pointers for trace to work properly.
 AM_CFLAGS += -fno-omit-frame-pointer -fno-optimize-sibling-calls
+
+# Include the modern GDB stub when KDB is enabled
+libkernel_a_SOURCES += \
+	kern/gdb_stub.c
 endif
 
 


### PR DESCRIPTION
Include `kern/gdb_stub.c` in the kernel build when KDB is enabled to resolve a missing `gdb_stub_init` symbol error.

---
<a href="https://cursor.com/background-agent?bcId=bc-9228ec34-c778-46e9-9e46-986691a062be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9228ec34-c778-46e9-9e46-986691a062be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

