### PR TITLE
Identify and repair critical errors

### DIFF
--- a/compiler-warnings.txt
+++ b/compiler-warnings.txt
@@ -1,6 +1,1 @@
-<<<<<<< HEAD
 make: *** No targets specified and no makefile found.  Stop.
-
-=======
-make: *** No targets specified and no makefile found.  Stop.
->>>>>>> aa0d18e47e778a761b80d125741fb7ad4a4a4e79

--- a/include/mach/machine
+++ b/include/mach/machine
@@ -1,0 +1,1 @@
+../../i386/include/mach/i386


### PR DESCRIPTION
Fix build errors by resolving a merge conflict in `compiler-warnings.txt` and adding a symbolic link for machine-specific headers.

The symbolic link `include/mach/machine` was created to resolve a build error where `mach/machine/vm_param.h` could not be found.

---
<a href="https://cursor.com/background-agent?bcId=bc-419be048-d5a9-4ba4-adb7-7c7d9530e316">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-419be048-d5a9-4ba4-adb7-7c7d9530e316">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

