### PR TITLE
Use local mig directory for builds

### DIFF
--- a/README
+++ b/README
@@ -85,9 +85,9 @@ the libera.chat IRC network in the #hurd channel.
 3. Install MIG (Mach Interface Generator):
 
    - `sudo apt install -y mig` (if available)
-   - If not available, build from source:
-     - `git clone https://git.savannah.gnu.org/git/hurd/mig.git`
+   - If not available, build from source using the included mig directory:
      - `cd mig && ./bootstrap && ./configure && make -j$(nproc) && sudo make install`
+     - Note: The mig source is already included in this repository
 
 4. Configure and build (from the project root mounted in WSL, e.g. `/mnt/d/curso/cognu-mach`):
 

--- a/cursor_analyze_codebase_and_suggest_nex.md
+++ b/cursor_analyze_codebase_and_suggest_nex.md
@@ -34,7 +34,7 @@ Skimmed the top-level docs, build system, and tests. Confirmed: autotools-based 
   sudo apt install -y mig || true   # Debian-based have 'mig'; if missing, build from source:
   # Build GNU MIG from source (fallback)
   sudo apt install -y texinfo
-  git clone https://git.savannah.gnu.org/git/hurd/mig.git
+  # Use the local mig directory (already included in the repository)
   cd mig && ./bootstrap && ./configure && make -j$(nproc) && sudo make install && cd ..
   ```
 - **Configure and build (32-bit target from 64-bit toolchain)**
@@ -105,7 +105,7 @@ Summary
   sudo apt install -y mig || true   # Debian-based have 'mig'; if missing, build from source:
   # Build GNU MIG from source (fallback)
   sudo apt install -y texinfo
-  git clone https://git.savannah.gnu.org/git/hurd/mig.git
+  # Use the local mig directory (already included in the repository)
   cd mig && ./bootstrap && ./configure && make -j$(nproc) && sudo make install && cd ..
 ```
 
@@ -129,4 +129,3 @@ Summary
   cppcheck --std=c11 --platform=unix32 --enable=warning,performance,portability --inline-suppr --error-exitcode=2 .
   scan-build --use-cc=gcc --use-c++=g++ -o scan-out make -j$(nproc) clean all
 ```
-

--- a/scripts/dev-setup-wsl.sh
+++ b/scripts/dev-setup-wsl.sh
@@ -13,11 +13,24 @@ fi
 
 if ! command -v mig >/dev/null 2>&1; then
   sudo apt install -y texinfo
-  rm -rf /tmp/mig-src
-  git clone https://git.savannah.gnu.org/git/hurd/mig.git /tmp/mig-src
-  pushd /tmp/mig-src
-  ./bootstrap
-  ./configure
+  # Use the local mig directory instead of downloading
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  MIG_DIR="$SCRIPT_DIR/../mig"
+  
+  if [ ! -d "$MIG_DIR" ]; then
+    echo "Error: Local mig directory not found at $MIG_DIR"
+    exit 1
+  fi
+  
+  pushd "$MIG_DIR"
+  # Check if bootstrap has already been run
+  if [ ! -f "configure" ]; then
+    ./bootstrap
+  fi
+  # Check if already configured
+  if [ ! -f "Makefile" ]; then
+    ./configure
+  fi
   make -j"$(nproc)"
   sudo make install
   popd


### PR DESCRIPTION
Use local 'mig' directory instead of downloading it to speed up setup and enable offline builds.

This change ensures consistency by using the version of mig included in the repository and improves efficiency by avoiding redundant downloads and build steps.

---
<a href="https://cursor.com/background-agent?bcId=bc-be0332a6-4c37-4f8e-8f36-81580b47b864">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be0332a6-4c37-4f8e-8f36-81580b47b864">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

