### PR TITLE
Fix type size mismatches and align request struct

### DIFF
--- a/i386/include/mach/i386/vm_types.h
+++ b/i386/include/mach/i386/vm_types.h
@@ -140,6 +140,24 @@ static inline int32_t convert_long_integer_to_user(int64_t i)
 }
 typedef uint32_t rpc_long_natural_t;
 typedef int32_t rpc_long_integer_t;
+#elif defined(MACH_KERNEL) && defined(KERNEL_USER)
+/*
+ * For kernel-compiled user stubs, force 64-bit rpc types so that
+ * MIG-generated Request/Reply sizes match host tool expectations.
+ */
+typedef uint64_t	rpc_uintptr_t;
+typedef uint64_t	rpc_vm_address_t;
+typedef uint64_t	rpc_vm_offset_t;
+typedef uint64_t	rpc_vm_size_t;
+
+#define convert_vm_to_user null_conversion
+#define convert_vm_from_user null_conversion
+
+typedef long_natural_t rpc_long_natural_t;
+typedef long_integer_t rpc_long_integer_t;
+
+#define convert_long_integer_to_user null_conversion
+#define convert_long_integer_from_user null_conversion
 #else /* MACH_KERNEL */
 typedef uintptr_t	rpc_uintptr_t;
 typedef vm_offset_t	rpc_vm_address_t;

--- a/include/mach/mach_types.defs
+++ b/include/mach/mach_types.defs
@@ -124,18 +124,18 @@ type ipc_space_t = mach_port_t
 type rpc_uintptr_t = uint32_t;
 type rpc_vm_size_t = uint32_t;
 #else /* KERNEL and USER32 */
-type rpc_uintptr_t = uintptr_t;
-type rpc_vm_size_t = uintptr_t;
+type rpc_uintptr_t = uint64_t;
+type rpc_vm_size_t = uint64_t;
 #endif /* KERNEL_SERVER and USER32 */
 
-type rpc_vm_offset_t = rpc_vm_size_t;
+ type rpc_vm_offset_t = rpc_vm_size_t;
 
 type vm_address_t = rpc_vm_size_t
 #if defined(KERNEL_SERVER)
     intran: vm_address_t convert_vm_from_user(rpc_vm_address_t)
     outtran: rpc_vm_address_t convert_vm_to_user(vm_address_t)
 #elif defined(KERNEL_USER)
-    ctype: rpc_vm_address_t
+    ctype: uint64_t
 #endif
     ;
 type vm_offset_t = rpc_vm_offset_t
@@ -143,7 +143,7 @@ type vm_offset_t = rpc_vm_offset_t
     intran: vm_offset_t convert_vm_from_user(rpc_vm_offset_t)
     outtran: rpc_vm_offset_t convert_vm_to_user(vm_offset_t)
 #elif defined(KERNEL_USER)
-    ctype: rpc_vm_offset_t
+    ctype: uint64_t
 #endif
     ;
 type vm_size_t = rpc_vm_size_t
@@ -151,7 +151,7 @@ type vm_size_t = rpc_vm_size_t
     intran: vm_size_t convert_vm_from_user(rpc_vm_size_t)
     outtran: rpc_vm_size_t convert_vm_to_user(vm_size_t)
 #elif defined(KERNEL_USER)
-    ctype: rpc_vm_size_t
+    ctype: uint64_t
 #endif
 ;
 type vm_prot_t = int;


### PR DESCRIPTION
Fix static assertion failures by ensuring 64-bit type consistency for VM sizes/offsets in MIG-generated user stubs.

The build was failing with static assertions in `vm/memory_object_user.user.c` because `rpc_vm_offset_t`, `rpc_vm_size_t`, and the `Request` struct had incorrect sizes. This was due to MIG (Mach Interface Generator) not consistently generating 64-bit types for VM sizes/offsets when user stubs were compiled within the kernel context, leading to discrepancies between the expected and actual sizes of these types and the `Request` struct. This PR ensures these types are explicitly 64-bit in the relevant contexts.

---
<a href="https://cursor.com/background-agent?bcId=bc-35caa6c2-7456-4424-9276-747a018f1ddb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35caa6c2-7456-4424-9276-747a018f1ddb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

